### PR TITLE
When outputting in directory mode, write target filename on error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor
+.idea/**

--- a/bogie/bogie.go
+++ b/bogie/bogie.go
@@ -88,7 +88,7 @@ func renderTemplateToDir(b *Bogie, apps []*applicationOutput) error {
 	for _, app := range apps {
 		hasContent, buff, err := runTemplate(app.context, b, app.template)
 		if err != nil {
-			return err
+			return fmt.Errorf("Error when writing to %s: %#v\n", app.outPath, err)
 		}
 
 		if hasContent {


### PR DESCRIPTION
When bogie is outputting the results in directory mode and an error
occurs, the name of the target file attempting to be written will
now be written to the console to allow for easier troubleshooting.

Also, added the .idea directory (project directory for Gogland) to
.gitignore file.